### PR TITLE
Fix hanged up decimal separator on formatICU & formatMaxDisplay

### DIFF
--- a/lib/src/money.dart
+++ b/lib/src/money.dart
@@ -772,7 +772,11 @@ extension FormatMaxDisplay on String {
       }
 
       final newDecimal = decimalPart.substring(0, maxDisplay);
-      final result = replaceRange(indexOf('.') + 1, length, newDecimal);
+
+      final result = newDecimal.isNotEmpty
+          ? replaceRange(indexOf('.') + 1, length, newDecimal)
+          : this.split('.').first;
+          
       if (index == 0) {
         return '$result$trailing';
       } else {

--- a/lib/src/money.dart
+++ b/lib/src/money.dart
@@ -453,7 +453,13 @@ class Money implements Comparable<Money> {
             decimalPart.substring(0, maxDisplayPrecision);
         //extract the symbol
         final result1 = decimalPart.replaceAll(RegExp('[^A-Za-z ]'), '');
-        final full = '$integerPart.$decimalWithTrailing$trailingIfMax$result1';
+        final decimalSeparator =
+            decimalWithTrailing.isEmpty ? '' : this.currency.decimalSeparator;
+
+        final full =
+            '$integerPart$decimalSeparator$decimalWithTrailing$trailingIfMax'
+            '$result1';
+
         return full.replaceAll(defaultLocale, currency.symbol);
       }
     }


### PR DESCRIPTION
### What is done:
- Fix hanged up decimal separator on formatICU & formatMaxDisplay if maxDisplayPrecision is used but decimal part is empty. 
Example: 
show `100` instead of `100.`
 