### PR TITLE
fix hanging decimal separator on formatICU()

### DIFF
--- a/lib/src/money.dart
+++ b/lib/src/money.dart
@@ -465,14 +465,22 @@ class Money implements Comparable<Money> {
 
       }
 
-      final checkLenght = decimalPart.replaceAll(RegExp(r'\s+[a-zA-Z]+$'), '');
+      final checkLength = decimalPart.replaceAll(RegExp(r'\s+[a-zA-Z]+$'), '');
 
-      if (checkLenght.length > maxDisplayPrecision) {
-        final decimalWithTrailing =
-            decimalPart.substring(0, maxDisplayPrecision);
+      if (checkLength.length > maxDisplayPrecision) {
+        final decimalWithTrailing = decimalPart.substring(
+          0,
+          maxDisplayPrecision,
+        );
+
+        final decimalSeparator = decimalWithTrailing.isNotEmpty
+            ? this.currency.decimalSeparator
+            : '';
+
         //extract the symbol
         final result1 = decimalPart.replaceAll(RegExp('[^A-Za-z ]'), '');
-        final full = '$integerPart.$decimalWithTrailing$trailingIfMax$result1';
+        final full =
+            '$integerPart$decimalSeparator$decimalWithTrailing$trailingIfMax$result1';
         return full.replaceAll(defaultLocale, currency.symbol);
       }
     }


### PR DESCRIPTION
this will fix hanging decimal separator on formatICU() when _**maxDisplayPrecision is 0**_ and _**trailingIfMax is '' (empty string)**_

Steps to reproduce:
1. Create a currency and assign its pattern
`final usdt = Currency.create('USDT', 2, pattern: '#,##0.## CCC');`
2. Create a money from the above currency that has decimal value 
`final usdtBalance = Money.fromIntWithCurrency(123, usdt);`
3. Print the money above with formatICU() function and  
--> _**maxDisplayPrecision is 0**_ 
--> _**trailingIfMax is '' (empty string)**_ 
` print('${usdtBalance.formatICU(maxDisplayPrecision: 0,trailingIfMax: '',)}');`

Print Result
- Before Fix (decimal separator is shown)
`1. USDT`
- After Fix (decimal separator is not shown)
`1 USDT`